### PR TITLE
changes for RAM limits, make new accessible method to get account ram usage

### DIFF
--- a/imports/eosio.imports.in
+++ b/imports/eosio.imports.in
@@ -45,6 +45,7 @@ is_feature_active
 activate_feature
 get_resource_limits
 set_resource_limits
+get_account_ram_usage
 set_proposed_producers
 get_blockchain_parameters_packed
 set_blockchain_parameters_packed

--- a/libraries/eosiolib/privileged.h
+++ b/libraries/eosiolib/privileged.h
@@ -29,6 +29,8 @@ extern "C" {
     * @param cpu_weight - fractionally proportionate cpu limit of available resources based on (weight / total_weight_of_all_accounts)
     */
    void set_resource_limits( capi_name account, int64_t ram_bytes, int64_t net_weight, int64_t cpu_weight );
+    
+   int64_t get_account_ram_usage( capi_name account);
 
    /**
     * Proposes a schedule change

--- a/libraries/native/intrinsics.cpp
+++ b/libraries/native/intrinsics.cpp
@@ -22,6 +22,9 @@ extern "C" {
    void set_resource_limits( capi_name account, int64_t ram_bytes, int64_t net_weight, int64_t cpu_weight ) {
       return intrinsics::get().call<intrinsics::set_resource_limits>(account, ram_bytes, net_weight, cpu_weight);
    }
+   int64_t get_account_ram_usage( capi_name account ) {
+        return intrinsics::get().call<intrinsics::get_account_ram_usage>(account);
+    }
    int64_t set_proposed_producers( char *producer_data, uint32_t producer_data_size ) {
       return intrinsics::get().call<intrinsics::set_proposed_producers>(producer_data, producer_data_size);
    }

--- a/libraries/native/intrinsics_def.hpp
+++ b/libraries/native/intrinsics_def.hpp
@@ -42,6 +42,7 @@ namespace eosio { namespace native {
 #define INTRINSICS(intrinsic_macro) \
 intrinsic_macro(get_resource_limits) \
 intrinsic_macro(set_resource_limits) \
+intrinsic_macro(get_account_ram_usage) \
 intrinsic_macro(set_proposed_producers) \
 intrinsic_macro(get_blockchain_parameters_packed) \
 intrinsic_macro(set_blockchain_parameters_packed) \


### PR DESCRIPTION
these changes provide a new method get_account_ram_usage to the smart contracts layer, this will be used as part of the new RAM limitations in the FIO protocol. these changes go along with the changes in FIO to provide the intrinsic for this method. Be sure to MERGE this and build along with the upcoming PR to the FIO repository.